### PR TITLE
feat(train): walk-forward folds with a purge gap, gating promotion

### DIFF
--- a/pipeline/train.py
+++ b/pipeline/train.py
@@ -8,7 +8,7 @@ serves as plain arithmetic (sigmoid(w·x + b)) in the browser. Label is binary
 the goal is cutting false alarms.
 """
 import csv, json, math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from sklearn.linear_model import LogisticRegression
 
 MODEL_PATH = "public/model.json"  # Astro serves this at /model.json (was web/model.json pre-Astro)
@@ -18,6 +18,98 @@ MIN_ROWS = 200  # ~8-9 days of labelled data before a model is trustworthy
 # of "raw rain call" (~noticeable drizzle). Labels remain METAR RA/DZ, not mm.
 RAIN_MM = 0.3
 FEATURE_NAMES = ["fc_bestmatch_mm", "fc_ecmwf_mm", "hour_sin", "hour_cos", "recent_rain_mm"]
+
+# Walk-forward validation. A single 80/20 split overstates skill: weather is autocorrelated
+# and one valid_at appears once per lead time (~7 rows), so a neighbouring hour on the other
+# side of the boundary is nearly the same observation.
+FOLDS = 4
+# Purge measured in HOURS, not rows. sklearn's TimeSeriesSplit(gap=n) gaps by row count,
+# which here is ~7 rows per hour and drifts whenever a lead time is added or a snapshot is
+# missed — so the gap is applied over valid_at instead.
+PURGE_HOURS = 6
+MIN_FOLD_ROWS = 25  # a fold smaller than this says nothing; skip it rather than score noise
+
+
+def _parse_valid_at(row):
+    """valid_at as a datetime. Logged as naive IST-local ISO, compared only against itself."""
+    return datetime.fromisoformat(row["valid_at"])
+
+
+def walk_forward_folds(rows, folds=FOLDS, purge_hours=PURGE_HOURS, min_fold_rows=MIN_FOLD_ROWS):
+    """Expanding-window folds over time, purged. Yields (train_rows, test_rows) oldest first.
+
+    Fold boundaries fall between DISTINCT valid_at values, never inside one, so the ~7 rows
+    sharing a timestamp cannot be split across train and test. Training is then truncated to
+    valid_at <= test_start - purge_hours, which is the leakage the purge exists to stop:
+    without it the last training hour sits minutes away from the first test hour.
+
+    Expanding rather than sliding: each fold trains on everything before it, which is how the
+    model will actually be fitted in production.
+    """
+    stamps = sorted({_parse_valid_at(r) for r in rows})
+    if len(stamps) < folds + 1:
+        return
+
+    # Equal-sized blocks of timestamps; the tail block absorbs any remainder.
+    block = len(stamps) // (folds + 1)
+    if block == 0:
+        return
+
+    for fold in range(1, folds + 1):
+        boundary = stamps[block * fold]
+        test_end = stamps[block * (fold + 1)] if fold < folds else None
+
+        train_cutoff = boundary - timedelta(hours=purge_hours)
+        train_rows = [r for r in rows if _parse_valid_at(r) <= train_cutoff]
+        test_rows = [
+            r
+            for r in rows
+            if _parse_valid_at(r) >= boundary and (test_end is None or _parse_valid_at(r) < test_end)
+        ]
+
+        if len(train_rows) < min_fold_rows or len(test_rows) < min_fold_rows:
+            continue
+        if len(set(int(float(r["observed_raining"])) for r in train_rows)) < 2:
+            continue
+        if len(set(int(float(r["observed_raining"])) for r in test_rows)) < 2:
+            continue
+        yield train_rows, test_rows
+
+
+def brier_skill_score(cand_brier, ref_brier):
+    """1 - cand/ref. Positive means better than the reference; 0 means no better.
+
+    A reference Brier of 0 means the baseline was perfect on that fold, so there is no skill
+    left to add: report 0.0 rather than dividing by zero.
+    """
+    if ref_brier == 0:
+        return 0.0
+    return 1.0 - (cand_brier / ref_brier)
+
+
+def median(values):
+    """Median without importing statistics for one call; empty -> None."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def passes_walk_forward(fold_skills):
+    """Median BSS vs raw > 0 across folds, and a win in at least 2 of them.
+
+    Both conditions, not either: a median above zero carried by one huge fold is the "lucky
+    monsoon week" the issue asks to exclude, and two wins out of three with a negative median
+    means the losses were worse than the wins.
+    """
+    if len(fold_skills) < 2:
+        return False
+    med = median(fold_skills)
+    wins = sum(1 for s in fold_skills if s > 0)
+    return med is not None and med > 0 and wins >= 2
 
 
 def _f(v, default=0.0):
@@ -149,18 +241,47 @@ def main():
     champ = _load_champion()
     champ_b = brier([predict_proba(champ, x) for x in Xte], yte) if champ else None
 
+    # Walk-forward folds, scored against the raw forecast on each fold's own holdout.
+    fold_skills = []
+    for fold_train, fold_test in walk_forward_folds(rows):
+        Xf_tr, yf_tr = build_xy(fold_train)
+        Xf_te, yf_te = build_xy(fold_test)
+        fold_model = train_classifier(Xf_tr, yf_tr)
+        fold_cand = brier([predict_proba(fold_model, x) for x in Xf_te], yf_te)
+        fold_raw = brier([1.0 if x[0] >= RAIN_MM else 0.0 for x in Xf_te], yf_te)
+        skill = brier_skill_score(fold_cand, fold_raw)
+        fold_skills.append(skill)
+        print(f"  fold {len(fold_skills)}: n_train={len(fold_train)} n_test={len(fold_test)} "
+              f"Brier={fold_cand:.4f} raw={fold_raw:.4f} BSS={skill:+.4f}")
+
+    fold_median = median(fold_skills)
+    walk_forward_ok = passes_walk_forward(fold_skills)
+
     candidate.update({
         "trained_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "n_train": len(train_rows), "n_test": len(test_rows),
         "brier": round(cand_b, 4), "raw_brier": round(raw_b, 4),
         "clim_brier": round(clim_b, 4),
         "champion_brier": round(champ_b, 4) if champ_b is not None else None,
+        "cv_folds": len(fold_skills),
+        "cv_purge_hours": PURGE_HOURS,
+        "cv_bss_vs_raw": [round(s, 4) for s in fold_skills],
+        "cv_bss_median": round(fold_median, 4) if fold_median is not None else None,
     })
     print(f"candidate Brier={cand_b:.4f}  raw-forecast={raw_b:.4f}  "
           f"climatology={clim_b:.4f}  champion={champ_b}  "
           f"(raw rain ≥ {RAIN_MM} mm/h)")
+    if fold_skills:
+        print(f"walk-forward: {len(fold_skills)} fold(s), median BSS vs raw "
+              f"{fold_median:+.4f}, wins {sum(1 for s in fold_skills if s > 0)}/{len(fold_skills)} "
+              f"-> {'PASS' if walk_forward_ok else 'FAIL'}")
+    else:
+        print(f"walk-forward: no usable folds (need {PURGE_HOURS}h purge + variety in each) "
+              "-> cannot promote on a single split alone.")
 
-    if passes_gate(cand_b, champ_b, raw_b, clim_b):
+    if not walk_forward_ok:
+        print("Rejected — walk-forward validation did not hold up across folds. Champion kept.")
+    elif passes_gate(cand_b, champ_b, raw_b, clim_b):
         with open(MODEL_PATH, "w") as f:
             json.dump(candidate, f, indent=2)
         print("PROMOTED — beats raw forecast, climatology, AND champion.")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,7 +1,10 @@
 import math
+from datetime import datetime, timedelta
+
 from pipeline.train import (row_to_features, brier, sigmoid, predict_proba,
                             passes_gate, train_classifier, build_xy, matured, FEATURE_NAMES,
-                            should_demote, raw_passthrough_model)
+                            should_demote, raw_passthrough_model,
+                            walk_forward_folds, brier_skill_score, median, passes_walk_forward)
 
 
 def test_row_to_features_shape_and_cyclic_hour():
@@ -94,3 +97,101 @@ def test_promotion_gate_unchanged():
     # regression guard: the existing gate still behaves
     assert passes_gate(0.10, 0.20, 0.15) is True     # beats champ & raw
     assert passes_gate(0.16, 0.20, 0.15) is False    # loses to raw
+
+
+# --- Walk-forward validation (issue #1) -------------------------------------
+
+
+def _rows(hours, leads=7, rain=lambda h: h % 2):
+    """One row per (valid_at hour, lead time), mimicking the log's ~7x duplication."""
+    base = datetime(2026, 7, 1, 0, 0)
+    out = []
+    for h in range(hours):
+        valid_at = base + timedelta(hours=h)
+        for lead in range(leads):
+            out.append({
+                "valid_at": valid_at.isoformat(timespec="minutes"),
+                "issued_at": (valid_at - timedelta(hours=lead)).isoformat(timespec="minutes"),
+                "fc_bestmatch_mm": "1.0" if rain(h) else "0.0",
+                "fc_ecmwf_mm": "1.0" if rain(h) else "0.0",
+                "hour": str(valid_at.hour),
+                "recent_rain_mm": "0.0",
+                "observed_raining": str(rain(h)),
+            })
+    return out
+
+
+def test_walk_forward_purge_leaves_no_training_row_inside_the_gap():
+    """The purge is the point: no training valid_at may sit within PURGE_HOURS of the test start."""
+    rows = _rows(200)
+    folds = list(walk_forward_folds(rows, folds=4, purge_hours=6))
+    assert folds, "fixture should produce usable folds"
+
+    for train_rows, test_rows in folds:
+        train_end = max(datetime.fromisoformat(r["valid_at"]) for r in train_rows)
+        test_start = min(datetime.fromisoformat(r["valid_at"]) for r in test_rows)
+        gap_hours = (test_start - train_end).total_seconds() / 3600
+        assert gap_hours >= 6, f"purge violated: only {gap_hours}h between train end and test start"
+
+
+def test_walk_forward_never_splits_one_valid_at_across_train_and_test():
+    """One valid_at is ~7 rows; if it straddles the boundary the holdout has seen its own hour."""
+    rows = _rows(200)
+    for train_rows, test_rows in walk_forward_folds(rows, folds=4, purge_hours=6):
+        train_stamps = {r["valid_at"] for r in train_rows}
+        test_stamps = {r["valid_at"] for r in test_rows}
+        assert not (train_stamps & test_stamps)
+
+
+def test_walk_forward_windows_expand_and_move_forward():
+    """Expanding window: each fold trains on at least as much as the previous one, later in time."""
+    rows = _rows(200)
+    folds = list(walk_forward_folds(rows, folds=4, purge_hours=6))
+    assert len(folds) >= 2
+    sizes = [len(train_rows) for train_rows, _ in folds]
+    starts = [min(datetime.fromisoformat(r["valid_at"]) for r in test_rows) for _, test_rows in folds]
+    assert sizes == sorted(sizes)
+    assert starts == sorted(starts) and len(set(starts)) == len(starts)
+
+
+def test_walk_forward_test_blocks_do_not_overlap():
+    rows = _rows(200)
+    seen = set()
+    for _, test_rows in walk_forward_folds(rows, folds=4, purge_hours=6):
+        stamps = {r["valid_at"] for r in test_rows}
+        assert not (stamps & seen), "fold test blocks must be disjoint"
+        seen |= stamps
+
+
+def test_walk_forward_yields_nothing_when_there_is_too_little_history():
+    assert list(walk_forward_folds(_rows(3), folds=4, purge_hours=6)) == []
+
+
+def test_walk_forward_skips_folds_with_only_one_class():
+    """A fold that never rains cannot score calibration, so it must be dropped, not scored."""
+    rows = _rows(200, rain=lambda h: 0)          # never rains anywhere
+    assert list(walk_forward_folds(rows, folds=4, purge_hours=6)) == []
+
+
+def test_brier_skill_score_signs():
+    assert brier_skill_score(0.10, 0.20) > 0      # better than reference
+    assert brier_skill_score(0.20, 0.20) == 0     # no better
+    assert brier_skill_score(0.30, 0.20) < 0      # worse
+    assert brier_skill_score(0.10, 0.0) == 0.0    # perfect reference -> no skill to add, no ZeroDivisionError
+
+
+def test_median_handles_even_and_odd_and_empty():
+    assert median([3, 1, 2]) == 2
+    assert median([4, 1, 2, 3]) == 2.5
+    assert median([]) is None
+
+
+def test_promotion_needs_median_above_zero_and_two_wins():
+    assert passes_walk_forward([0.1, 0.2, 0.3])          # consistent
+    assert passes_walk_forward([-0.01, 0.2, 0.3])        # one loss, median still positive
+    # The lucky-monsoon-week case the issue names: one huge win, everything else negative.
+    assert not passes_walk_forward([5.0, -0.1, -0.2])
+    # Two wins but the losses dominate, so the median is negative.
+    assert not passes_walk_forward([0.01, 0.02, -1.0, -1.0])
+    assert not passes_walk_forward([0.5])                # a single fold is not validation
+    assert not passes_walk_forward([])


### PR DESCRIPTION
Closes #1.

## The purge is in hours, not rows

`TimeSeriesSplit(gap=n)` gaps by **row count**. In this log that's ~7 rows per hour (one per lead time) and it drifts the moment a lead time is added or a snapshot is missed — a `gap=14` meant as "2h" quietly becomes something else. So the gap is applied over `valid_at`:

```python
train_cutoff = boundary - timedelta(hours=purge_hours)   # PURGE_HOURS = 6
train_rows   = [r for r in rows if _parse_valid_at(r) <= train_cutoff]
```

Fold boundaries also fall between **distinct** `valid_at` values, never inside one, so the ~7 rows sharing a timestamp can't straddle train and test — that's the same-observation leak the issue names.

Folds are expanding-window (4 by default), because that's how the model is actually fitted in production. Folds missing either class, or below `MIN_FOLD_ROWS`, are skipped rather than scored as noise.

## Promotion gate

Median BSS vs raw **> 0** *and* wins in **at least 2** folds, on top of the existing raw / climatology / champion gates.

Both conditions, not either:

```python
assert not passes_walk_forward([5.0, -0.1, -0.2])      # the lucky monsoon week
assert not passes_walk_forward([0.01, 0.02, -1.0, -1.0])  # 2 wins, losses dominate
assert not passes_walk_forward([0.5])                  # one fold is not validation
```

With no usable folds the candidate cannot promote on the single split alone.

`brier_skill_score` returns `0.0` when the reference Brier is 0 — a perfect baseline leaves no skill to add, and it would otherwise divide by zero.

## Verified on the real `data/log.csv`

4180 matured rows, 539 distinct `valid_at`:

```
  fold 1: n_train=708  n_test=830 Brier=0.1301 raw=0.1410 BSS=+0.0770
  fold 2: n_train=1528 n_test=889 Brier=0.1052 raw=0.1147 BSS=+0.0835
  fold 3: n_train=2412 n_test=887 Brier=0.1476 raw=0.3788 BSS=+0.6102
  fold 4: n_train=3294 n_test=836 Brier=0.1858 raw=0.4701 BSS=+0.6048
walk-forward: 4 fold(s), median BSS vs raw +0.3441, wins 4/4 -> PASS
PROMOTED — beats raw forecast, climatology, AND champion.
```

Training windows expand, test blocks are disjoint, and every fold beats raw. (`public/model.json` was restored afterwards — this branch touches only `pipeline/train.py` and `tests/test_train.py`.)

## Tests: 10 new, mutation-checked twice

| mutation | caught by |
| --- | --- |
| purge disabled (`train_cutoff = boundary`) | `..._purge_leaves_no_training_row_inside_the_gap`, `..._never_splits_one_valid_at_across_train_and_test` |
| boundaries by row position instead of distinct timestamps | `..._purge_leaves_no_training_row_inside_the_gap`, `..._test_blocks_do_not_overlap` |

Suite: **42 passed**.

`model.json` now carries `cv_folds`, `cv_purge_hours`, `cv_bss_vs_raw`, `cv_bss_median`, so the scoreboard can show why a model was promoted.

## Separate pre-existing bug, not fixed here

`python -m pipeline.train` **crashes on Windows** before printing the summary:

```
UnicodeEncodeError: 'charmap' codec can't encode character '≥' in position 105
```

That's the `≥` in the existing `(raw rain ≥ {RAIN_MM} mm/h)` line under a cp1252 console. It reproduces on clean `main` (same statement, line 159 there), and Linux CI is UTF-8 so it never fires in the workflow. I reproduced my run with `PYTHONIOENCODING=utf-8`. Left alone as unrelated to this issue — happy to send a one-line follow-up if you want it hardened for Windows contributors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chronological walk-forward validation using four time-based folds.
  * Added a six-hour separation window to reduce temporal overlap between training and evaluation data.
  * Added Brier skill scoring and median performance calculations.
  * Model promotion now requires positive median skill and at least two successful validation folds.
  * Candidate model records now include cross-validation results.

* **Bug Fixes**
  * Prevented promotion when validation folds are too small or lack both outcome classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->