### PR TITLE
docs: add CONTRIBUTING.md and link it from the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for looking. This is a small, deliberately narrow project: a rain nowcast for Mumbai only, with a public scoreboard so the claims can be checked. Contributions that keep it honest and specific are very welcome.
+
+## Five-minute setup
+
+Two independent halves. You only need the one you're touching.
+
+### Web (Astro)
+
+```bash
+bun install          # or: npm install
+bun run dev          # http://localhost:4321
+```
+
+Node 18+ or Bun. `bun run build` produces the production build.
+
+### Pipeline (Python)
+
+```bash
+uv sync              # creates .venv and installs everything, including dev deps
+uv run pytest -q
+```
+
+Python 3.11+, managed with [`uv`](https://docs.astral.sh/uv/) — no hand-rolled venv paths.
+
+If `uv` is new to you: `uv sync` replaces `python -m venv` + `pip install`, and `uv run <cmd>` runs `<cmd>` inside that environment without activating it.
+
+## Running the tests
+
+```bash
+uv run pytest -q                       # the whole suite
+uv run pytest tests/test_train.py -q   # one file
+```
+
+`tests/` is pytest over `pipeline/`. There is no test suite for the Astro side yet, so web changes are verified by running `bun run dev` and looking.
+
+**Windows note:** several pipeline modules print `≥` and `→`, which a default `cp1252` console cannot encode, so a command can die with `UnicodeEncodeError` before printing its summary. Prefix with `PYTHONIOENCODING=utf-8` if you hit it. CI runs on Linux with UTF-8 and never sees this.
+
+## How health and the scoreboard work
+
+These two are how the project keeps itself accountable, so it helps to run them before proposing a change to the pipeline.
+
+```bash
+uv run python -m pipeline.health          # summary, and writes public/metrics.json
+uv run python -m pipeline.health --fail-stale 12
+uv run python -m pipeline.train           # retrain; promotes only if it earns it
+```
+
+`pipeline/health.py` prints one line per concern and exits non-zero when something is wrong, which is what CI gates on:
+
+```
+collect     last=... stale_h=1.47  level=ok  gaps>1h=171 max=511.0h
+model       type=logistic  trained_at=...  stored_brier=0.1941
+holdout     n_test=836  model=0.186  raw=0.4701  clim=0.2672  status=ok
+bss         vs_raw=0.6044  vs_clim=0.3039
+go_live     data=True logistic=True beats_raw=True beats_clim=True fresh=True
+```
+
+It also writes `public/metrics.json`, which the site serves at `/metrics.json` and `/scoreboard` renders. So the scoreboard is not a separate calculation — change the numbers in `health.py` and the page follows.
+
+`pipeline/train.py` trains a candidate and **only** overwrites `public/model.json` if the candidate beats the raw forecast, climatology, and the current champion, across walk-forward folds with a purge gap. A candidate that wins one lucky week does not get promoted. Running it locally is safe to inspect, but note that a passing candidate **will** rewrite `public/model.json` — check `git status` afterwards and revert if you did not mean to commit a retrain.
+
+## The data is the database
+
+`data/log.csv` grows hourly via `.github/workflows/collect.yml`. Treat it as append-only: don't rewrite history, and don't reformat it in a PR, because every diff there is also a change to the training set.
+
+## What makes a good PR
+
+- **One concern per PR.** Easier to review, easier to revert.
+- **Say how you verified it.** For pipeline work, the numbers before and after. For web work, what you clicked.
+- **Don't widen the scope.** "Mumbai only" and "no API keys on the live path" are deliberate constraints, not gaps.
+- **No silent magic.** If a change affects the published probability, the method has to stay explainable on `/about` and checkable on `/scoreboard`.
+
+Tests are expected for pipeline logic. If a change is hard to test, say so in the PR rather than skipping it quietly.
+
+## First PR ideas
+
+Issues are labelled — start here:
+
+- [good first issue](https://github.com/Ishannaik/mumbai-rain/labels/good%20first%20issue) — scoped, with hints in the body
+- [docs](https://github.com/Ishannaik/mumbai-rain/labels/docs) — wording, setup, explanation
+- [help wanted](https://github.com/Ishannaik/mumbai-rain/labels/help%20wanted) — open to anyone
+
+Before starting something larger, comment on the issue so two people don't build it twice.
+
+## Code of conduct
+
+Be decent. Assume good faith, keep review about the work, and accept that "no" to a feature is usually about scope rather than about you.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Returns JSON: calibrated rain probability, verdict text, flood-risk nearest zone
 - **No silent “AI magic”** — method, data split, and scoreboard are public
 - Product voice and method: site `/about`; early specs live under `archive/`
 
+## Contributing
+
+Setup, how to run the tests, and how `health` and `/scoreboard` fit together:
+[CONTRIBUTING.md](./CONTRIBUTING.md). Good places to start are the
+[good first issue](https://github.com/Ishannaik/mumbai-rain/labels/good%20first%20issue)
+and [docs](https://github.com/Ishannaik/mumbai-rain/labels/docs) labels.
+
 ## License
 
 [MIT](./LICENSE) · Weather data by [Open-Meteo](https://open-meteo.com/)


### PR DESCRIPTION
Closes #7.

Adds `CONTRIBUTING.md` and links it from the README (new Contributing section above License).

## Every command in it was actually run

Not copied from the README — executed against this checkout:

```
uv run pytest -q                      -> 33 passed
uv run python -m pipeline.health      -> the 6-line summary quoted in the doc
gh label list -R Ishannaik/mumbai-rain -> confirmed the labels the "first PR ideas" links point at
```

So the health output in the doc is real output, which means a newcomer can compare their run against a known-good one.

## What it covers beyond the checklist

**Both halves separately**, since a contributor usually only needs one — plus a line on what `uv sync` / `uv run` replace, for anyone who hasn't used uv.

**health and the scoreboard as one thing, not two.** `health.py` writes `public/metrics.json`, the site serves it at `/metrics.json`, and `/scoreboard` renders that — so changing the numbers in `health.py` moves the page. That relationship isn't obvious from the file layout and it's the thing most likely to cause a confused PR.

**A warning I'd have wanted:** running `pipeline.train` locally *will* rewrite `public/model.json` if the candidate passes the gate. Very easy to commit by accident — I nearly did while working on #1.

**The Windows `cp1252` trap.** Several pipeline modules print `≥` / `→`, so a command dies with `UnicodeEncodeError` before printing its summary on a default Windows console. `PYTHONIOENCODING=utf-8` works around it. This cost me real time on this machine and would cost the next Windows contributor the same. (It reproduces on clean `main`; CI is Linux/UTF-8 so it never fires there.)

**`data/log.csv` is append-only** — a reformat there is also a change to the training set.

## Two judgement calls for you

- **Code of conduct** is a short paragraph rather than the vendored Contributor Covenant, since the issue marks it optional. Happy to swap in the full text as `CODE_OF_CONDUCT.md` if you'd prefer.
- I did **not** claim there are web-side tests, because there aren't any — the doc says web changes are verified by running `bun run dev` and looking. Correct me if something exists that I missed.
