### PR TITLE
a11y: skip-to-content link on Now + section pages

### DIFF
--- a/src/layouts/Almanac.astro
+++ b/src/layouts/Almanac.astro
@@ -121,6 +121,7 @@ const defaultIdx = defaultLocality
 
 </head>
 <body>
+  <a class="skip-link" href="#app">Skip to content</a>
   <!-- THE RISING WATER — the signature. Visible WITHOUT JS (calm base line);
        JS only raises/tints it. -->
   <div id="water" class="water" role="img" aria-label="Calm — no flooding"></div>
@@ -134,7 +135,7 @@ const defaultIdx = defaultLocality
        pointer-events:none, behind #app. -->
   <div id="rain-canvas" class="rain-layer" aria-hidden="true"></div>
 
-  <main id="app" class="state-loading" data-default-locality={defaultLocality ?? ""}>
+  <main id="app" class="state-loading" tabindex="-1" data-default-locality={defaultLocality ?? ""}>
     <!-- Masthead: the Marathi anchor (identity, constant ink) + the picker. -->
     <header class="masthead">
       <span class="anchor" lang="mr">पाऊस</span>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -125,7 +125,8 @@ const NAV = [
   />
 </head>
 <body>
-  <main id={col.id} class={col.cls}>
+  <a class="skip-link" href={`#${col.id ?? "content"}`}>Skip to content</a>
+  <main id={col.id ?? "content"} class={col.cls} tabindex="-1">
     <!-- Masthead: the Marathi anchor (constant ink identity) + section nav. -->
     <header class="masthead">
       <span class="anchor" lang="mr">पाऊस</span>

--- a/src/styles/almanac.css
+++ b/src/styles/almanac.css
@@ -35,6 +35,36 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html { -webkit-text-size-adjust: 100%; background: var(--paper); }
 
+/* Skip link — keyboard-only path to main content (invisible until focused). */
+.skip-link {
+  position: absolute;
+  left: 0.75rem;
+  top: 0.75rem;
+  z-index: 100;
+  padding: 0.5rem 0.75rem;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.8125rem;
+  text-decoration: none;
+  border: 2px solid var(--ink);
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.skip-link:focus {
+  clip-path: none;
+  clip: auto;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  outline: 2px solid var(--radar-rain);
+  outline-offset: 2px;
+}
+
 body {
   min-height: 100svh;
   background: var(--paper);


### PR DESCRIPTION
﻿Keyboard users can jump past the masthead (and decorative water/rain on Now) to main content.

- Shared `.skip-link` in `almanac.css`
- `Page.astro` + `Almanac.astro`
- `tabindex="-1"` on main so focus lands after skip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added keyboard-accessible skip links to jump directly to the main content.
  - Skip links become visible when focused.
  - Improved keyboard navigation by making main content programmatically focusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->