### PR TITLE
feat(scoreboard): reliability table + POD/FAR/CSI/bias at p>=0.5

### DIFF
--- a/src/lib/skill.js
+++ b/src/lib/skill.js
@@ -1,0 +1,85 @@
+// Calibration and contingency metrics for the holdout scoreboard.
+//
+// Brier alone hides miscalibration: a model that always says 30% on a 30%-rain
+// climate scores well while being useless for a decision. These two answer the
+// questions Brier cannot — "when we say 70%, does it rain ~70%?" (reliability)
+// and "at the p >= 0.5 button-press, what do we hit and miss?" (contingency).
+//
+// Pure functions with no I/O so the scoreboard build and `bun test` share one
+// implementation. Run with `bun test`.
+
+/**
+ * Bin forecast probabilities and compare mean forecast to observed frequency.
+ *
+ * A perfectly calibrated model has `observed ≈ forecast` in every populated bin;
+ * that is the diagonal a reliability diagram plots against.
+ *
+ * @param {number[]} probs   forecast probabilities in [0, 1]
+ * @param {number[]} actual  matching outcomes, 1 = it rained, 0 = it did not
+ * @param {number}   nBins   number of equal-width bins (default 10)
+ * @returns {{lo:number, hi:number, n:number, forecast:number|null,
+ *            observed:number|null}[]} one row per bin, low edge ascending
+ */
+export function reliabilityBins(probs, actual, nBins = 10) {
+  if (nBins < 1) throw new RangeError("nBins must be >= 1");
+
+  const bins = Array.from({ length: nBins }, (_, i) => ({
+    lo: i / nBins,
+    hi: (i + 1) / nBins,
+    n: 0,
+    sumForecast: 0,
+    sumObserved: 0,
+  }));
+
+  const n = Math.min(probs.length, actual.length);
+  for (let i = 0; i < n; i++) {
+    const p = probs[i];
+    if (!Number.isFinite(p)) continue;
+    // Clamp so p == 1 lands in the top bin rather than falling off the end.
+    const idx = Math.min(nBins - 1, Math.max(0, Math.floor(p * nBins)));
+    const bin = bins[idx];
+    bin.n++;
+    bin.sumForecast += p;
+    bin.sumObserved += actual[i] === 1 ? 1 : 0;
+  }
+
+  return bins.map((b) => ({
+    lo: b.lo,
+    hi: b.hi,
+    n: b.n,
+    forecast: b.n ? b.sumForecast / b.n : null,
+    observed: b.n ? b.sumObserved / b.n : null,
+  }));
+}
+
+/**
+ * Contingency scores at a decision threshold, from a 2x2 confusion matrix.
+ *
+ * - `pod`  probability of detection (hit rate): of the times it rained, how
+ *          often did we call it? TP / (TP + FN)
+ * - `far`  false alarm ratio: of the times we called rain, how often were we
+ *          wrong? FP / (TP + FP)
+ * - `csi`  critical success index (threat score), which unlike accuracy is not
+ *          flattered by the many correct-dry hours: TP / (TP + FP + FN)
+ * - `bias` frequency bias: how often we call rain vs how often it rains.
+ *          1 = right on average, > 1 = over-forecasting. (TP + FP) / (TP + FN)
+ *
+ * Each is null when its denominator is zero, rather than 0 or NaN — "never
+ * rained in the holdout" is a different statement from "we detected nothing".
+ *
+ * @param {{tp:number, fp:number, fn:number, tn:number}} m
+ * @returns {{pod:number|null, far:number|null, csi:number|null, bias:number|null}}
+ */
+export function contingencyScores({ tp, fp, fn, tn }) {
+  const observedRain = tp + fn;
+  const calledRain = tp + fp;
+  const csiDenom = tp + fp + fn;
+  void tn; // present for completeness; none of these four scores use it
+
+  return {
+    pod: observedRain > 0 ? tp / observedRain : null,
+    far: calledRain > 0 ? fp / calledRain : null,
+    csi: csiDenom > 0 ? tp / csiDenom : null,
+    bias: observedRain > 0 ? calledRain / observedRain : null,
+  };
+}

--- a/src/lib/skill.test.js
+++ b/src/lib/skill.test.js
@@ -1,0 +1,139 @@
+// Unit tests for the calibration / contingency maths behind the scoreboard.
+// Run with `bun test`.
+
+import { test, expect } from "bun:test";
+import { reliabilityBins, contingencyScores } from "./skill.js";
+
+// ── reliabilityBins ─────────────────────────────────────────────────────────
+
+test("a perfectly calibrated forecast sits on the diagonal", () => {
+  // 10 forecasts at 0.9, nine of which rain -> observed 0.9 in the top bin.
+  const probs = Array(10).fill(0.9);
+  const actual = [1, 1, 1, 1, 1, 1, 1, 1, 1, 0];
+
+  const top = reliabilityBins(probs, actual).at(-1);
+
+  expect(top.n).toBe(10);
+  expect(top.forecast).toBeCloseTo(0.9, 10);
+  expect(top.observed).toBeCloseTo(0.9, 10);
+});
+
+test("an over-confident forecast shows observed below forecast", () => {
+  // Says 0.8 ten times, only rains twice.
+  const probs = Array(10).fill(0.8);
+  const actual = [1, 1, 0, 0, 0, 0, 0, 0, 0, 0];
+
+  const bin = reliabilityBins(probs, actual).find((b) => b.n > 0);
+
+  expect(bin.forecast).toBeCloseTo(0.8, 10);
+  expect(bin.observed).toBeCloseTo(0.2, 10);
+  expect(bin.observed).toBeLessThan(bin.forecast);
+});
+
+test("empty bins report null rather than zero", () => {
+  // A zero observed frequency and "nothing landed here" must not look alike.
+  const bins = reliabilityBins([0.05], [0]);
+
+  expect(bins[0].n).toBe(1);
+  expect(bins[0].observed).toBe(0);
+  expect(bins[5].n).toBe(0);
+  expect(bins[5].observed).toBeNull();
+  expect(bins[5].forecast).toBeNull();
+});
+
+test("p = 1 lands in the top bin, not off the end", () => {
+  const bins = reliabilityBins([1], [1]);
+
+  expect(bins.at(-1).n).toBe(1);
+  expect(bins.reduce((s, b) => s + b.n, 0)).toBe(1);
+});
+
+test("p = 0 lands in the first bin", () => {
+  const bins = reliabilityBins([0], [0]);
+
+  expect(bins[0].n).toBe(1);
+});
+
+test("every observation is counted exactly once", () => {
+  const probs = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1];
+  const actual = [0, 0, 1, 0, 1, 1, 1];
+
+  const bins = reliabilityBins(probs, actual);
+
+  expect(bins.reduce((s, b) => s + b.n, 0)).toBe(probs.length);
+});
+
+test("bin edges tile [0,1] with no gap or overlap", () => {
+  const bins = reliabilityBins([], [], 5);
+
+  expect(bins).toHaveLength(5);
+  expect(bins[0].lo).toBe(0);
+  expect(bins.at(-1).hi).toBe(1);
+  for (let i = 1; i < bins.length; i++) expect(bins[i].lo).toBe(bins[i - 1].hi);
+});
+
+test("non-finite probabilities are skipped, not binned as 0", () => {
+  const bins = reliabilityBins([NaN, 0.95], [1, 1]);
+
+  expect(bins.reduce((s, b) => s + b.n, 0)).toBe(1);
+  expect(bins[0].n).toBe(0);
+});
+
+test("bin count is configurable", () => {
+  expect(reliabilityBins([], [], 5)).toHaveLength(5);
+  expect(() => reliabilityBins([], [], 0)).toThrow(RangeError);
+});
+
+// ── contingencyScores ───────────────────────────────────────────────────────
+
+test("a textbook confusion matrix gives the textbook scores", () => {
+  // 8 rain hours: 6 caught, 2 missed. 10 rain calls: 6 right, 4 wrong.
+  const s = contingencyScores({ tp: 6, fp: 4, fn: 2, tn: 88 });
+
+  expect(s.pod).toBeCloseTo(6 / 8, 10);
+  expect(s.far).toBeCloseTo(4 / 10, 10);
+  expect(s.csi).toBeCloseTo(6 / 12, 10);
+  expect(s.bias).toBeCloseTo(10 / 8, 10);
+});
+
+test("a perfect forecast scores POD 1, FAR 0, CSI 1, bias 1", () => {
+  const s = contingencyScores({ tp: 5, fp: 0, fn: 0, tn: 20 });
+
+  expect(s.pod).toBe(1);
+  expect(s.far).toBe(0);
+  expect(s.csi).toBe(1);
+  expect(s.bias).toBe(1);
+});
+
+test("bias separates over- from under-forecasting", () => {
+  expect(contingencyScores({ tp: 5, fp: 5, fn: 0, tn: 10 }).bias).toBeCloseTo(2, 10);
+  expect(contingencyScores({ tp: 5, fp: 0, fn: 5, tn: 10 }).bias).toBeCloseTo(0.5, 10);
+});
+
+test("zero denominators give null, never NaN", () => {
+  // Never rained in the holdout: POD and bias are undefined, not zero.
+  const noRain = contingencyScores({ tp: 0, fp: 3, fn: 0, tn: 40 });
+  expect(noRain.pod).toBeNull();
+  expect(noRain.bias).toBeNull();
+  expect(noRain.far).toBe(1);
+
+  // Never called rain: FAR is undefined.
+  const noCalls = contingencyScores({ tp: 0, fp: 0, fn: 4, tn: 40 });
+  expect(noCalls.far).toBeNull();
+  expect(noCalls.pod).toBe(0);
+
+  // Nothing happened at all.
+  const empty = contingencyScores({ tp: 0, fp: 0, fn: 0, tn: 0 });
+  expect(empty.pod).toBeNull();
+  expect(empty.far).toBeNull();
+  expect(empty.csi).toBeNull();
+  expect(empty.bias).toBeNull();
+});
+
+test("CSI ignores correct-dry hours, unlike accuracy", () => {
+  // Same rain performance, wildly different dry counts: CSI must not move.
+  const a = contingencyScores({ tp: 3, fp: 2, fn: 1, tn: 10 });
+  const b = contingencyScores({ tp: 3, fp: 2, fn: 1, tn: 100_000 });
+
+  expect(a.csi).toBe(b.csi);
+});

--- a/src/pages/scoreboard.astro
+++ b/src/pages/scoreboard.astro
@@ -7,6 +7,7 @@
 // the log" page that a service worker can cache forever.
 import Page from "../layouts/Page.astro";
 import { loadLogCsv, loadModelJson } from "../lib/log-csv.js";
+import { reliabilityBins, contingencyScores } from "../lib/skill.js";
 
 // Must match pipeline/train.py RAIN_MM and nowcast.js RAIN_THRESHOLD_MM.
 const RAIN_TH = 0.3;
@@ -90,6 +91,11 @@ const fmtBrier = (v: number | null | undefined) =>
   v == null || !Number.isFinite(v) ? "—" : v.toFixed(4);
 const fmtBss = (v: number | null | undefined) =>
   v == null || !Number.isFinite(v) ? "—" : (v >= 0 ? "+" : "") + (100 * v).toFixed(1) + "%";
+// A rate in [0,1] as a percentage. Distinct from fmtPct, which takes n/d.
+const fmtRate = (v: number | null | undefined) =>
+  v == null || !Number.isFinite(v) ? "—" : (100 * v).toFixed(1) + "%";
+const fmtRatio = (v: number | null | undefined) =>
+  v == null || !Number.isFinite(v) ? "—" : v.toFixed(2);
 
 const baseRate = fmtPct(observedRain, nLab);
 const pod = fmtPct(TP, observedRain);
@@ -133,7 +139,13 @@ type Holdout = {
   bssRaw: number | null; bssClim: number | null;
   mTP: number; mFP: number; mFN: number; mTN: number;
   beatsRaw: boolean; beatsClim: boolean; status: string;
+  reliability: { lo: number; hi: number; n: number; forecast: number | null; observed: number | null }[];
+  pod: number | null; far: number | null; csi: number | null; bias: number | null;
 };
+
+// 5 bins, not 10: with a few hundred holdout rows a 10-bin table is mostly
+// empty cells, and an "observed" frequency over 3 samples is noise, not signal.
+const RELIABILITY_BINS = 5;
 
 let holdout: Holdout | null = null;
 if (enoughData) {
@@ -151,6 +163,7 @@ if (enoughData) {
     const climB = brierScore(Xte.map(() => base), yte)!;
     let modelB: number | null = null;
     let mTP = 0, mFP = 0, mFN = 0, mTN = 0;
+    let reliability: Holdout["reliability"] = [];
     if (isLogistic) {
       const probs = Xte.map((x) => predictProba(model!, x));
       modelB = brierScore(probs, yte);
@@ -162,7 +175,9 @@ if (enoughData) {
         else if (!called && did) mFN++;
         else mTN++;
       }
+      reliability = reliabilityBins(probs, yte, RELIABILITY_BINS);
     }
+    const scores = contingencyScores({ tp: mTP, fp: mFP, fn: mFN, tn: mTN });
     const beatsRaw = modelB != null && modelB <= rawB;
     const beatsClim = modelB != null && modelB <= climB;
     holdout = {
@@ -172,6 +187,8 @@ if (enoughData) {
       bssClim: modelB != null && climB > 0 ? 1 - modelB / climB : null,
       mTP, mFP, mFN, mTN, beatsRaw, beatsClim,
       status: !isLogistic ? "raw-fallback" : beatsRaw && beatsClim ? "ok" : "degraded",
+      reliability,
+      pod: scores.pod, far: scores.far, csi: scores.csi, bias: scores.bias,
     };
   }
 }
@@ -336,6 +353,69 @@ const description =
               On the holdout, logistic p≥{RAIN_PROB}:
               {" "}{holdout.mTP} hits · {holdout.mFP} false alarms · {holdout.mFN} misses · {holdout.mTN} correct dry.
             </p>
+          )}
+
+          {isLogistic && (
+            <>
+              <h3 class="sb-h3">At the decision threshold (p≥{RAIN_PROB})</h3>
+              <p class="sb-note">
+                What the numbers above mean if you actually act on them. CSI ignores the
+                many correct-dry hours, so unlike accuracy it can't be flattered by a
+                dry month.
+              </p>
+              <dl class="sb-stats">
+                <div class="sb-stat">
+                  <dt>POD</dt>
+                  <dd class="sb-n">{fmtRate(holdout.pod)}</dd>
+                  <p class="sb-stat-sub">of rainy hours we called</p>
+                </div>
+                <div class="sb-stat">
+                  <dt>FAR</dt>
+                  <dd class="sb-n">{fmtRate(holdout.far)}</dd>
+                  <p class="sb-stat-sub">of rain calls that were wrong</p>
+                </div>
+                <div class="sb-stat">
+                  <dt>CSI</dt>
+                  <dd class="sb-n">{fmtRate(holdout.csi)}</dd>
+                  <p class="sb-stat-sub">threat score, dry hours excluded</p>
+                </div>
+                <div class="sb-stat">
+                  <dt>Bias</dt>
+                  <dd class="sb-n">{fmtRatio(holdout.bias)}</dd>
+                  <p class="sb-stat-sub">1.00 = we call rain as often as it rains</p>
+                </div>
+              </dl>
+
+              <h3 class="sb-h3">Reliability — when we say X%, does it rain X%?</h3>
+              <p class="sb-note">
+                Brier alone hides miscalibration. A well-calibrated model has
+                <em>observed</em> close to <em>forecast</em> on every row; that is the
+                diagonal a reliability diagram draws. Rows with no holdout hours are
+                left blank rather than shown as zero.
+              </p>
+              <table class="sb-table sb-reliability">
+                <thead>
+                  <tr>
+                    <th scope="col">Forecast band</th>
+                    <th scope="col">Hours</th>
+                    <th scope="col">Mean forecast</th>
+                    <th scope="col">Observed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {holdout.reliability.map((b) => (
+                    <tr>
+                      <th scope="row">
+                        {Math.round(100 * b.lo)}–{Math.round(100 * b.hi)}%
+                      </th>
+                      <td>{b.n || "—"}</td>
+                      <td>{fmtRate(b.forecast)}</td>
+                      <td>{fmtRate(b.observed)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
           )}
         </section>
       )}
@@ -660,6 +740,34 @@ const description =
     margin-top: var(--s-4); max-width: 38rem;
   }
   .sb-reading-ok { border-left-color: var(--radar-rain); }
+
+  .sb-h3 {
+    font-family: "Fraunces", Georgia, serif; font-weight: 600;
+    font-size: clamp(1.02rem, 3.4vw, 1.16rem); line-height: 1.15;
+    color: var(--ink); letter-spacing: -.005em;
+    margin-top: var(--s-5); margin-bottom: var(--s-3);
+  }
+  .sb-note {
+    font-family: "IBM Plex Mono", monospace; font-size: .72rem; line-height: 1.55;
+    color: var(--ink-soft); margin-bottom: var(--s-3); max-width: 38rem;
+  }
+  .sb-note em { font-style: normal; color: var(--ink); }
+
+  .sb-table {
+    width: 100%; border-collapse: collapse;
+    font-family: "IBM Plex Mono", monospace; font-size: .74rem;
+    border-top: 1px solid var(--rule);
+  }
+  .sb-table th, .sb-table td {
+    padding: var(--s-3) var(--s-3); border-bottom: 1px solid var(--rule);
+    text-align: right; color: var(--ink);
+  }
+  .sb-table thead th {
+    font-size: .6rem; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--ink-soft); font-weight: 400;
+  }
+  .sb-table tbody th[scope="row"] { text-align: left; font-weight: 400; }
+  .sb-table th:first-child, .sb-table td:first-child { text-align: left; }
 
   .sb-gate { list-style: none; display: flex; flex-direction: column; gap: 2px; }
   .sb-gate li {


### PR DESCRIPTION
Closes #2.

## What

Brier alone hides miscalibration — a model that always says 30% on a 30%-rain climate scores respectably while being useless to act on. The board already computed the holdout confusion matrix but only printed the four raw counts, so neither question a user actually has got answered.

New `src/lib/skill.js`, two pure functions:

- **`reliabilityBins()`** — buckets forecast probabilities, reports mean forecast vs observed frequency per bin.
- **`contingencyScores()`** — derives POD / FAR / CSI / frequency bias from the confusion matrix that was *already* being computed, so this adds no new model maths.

Both render under the existing holdout section.

## What it immediately shows

This is the part I think justifies the issue. Built against current `data/log.csv`:

| Forecast band | Hours | Mean forecast | Observed |
| --- | ---: | ---: | ---: |
| 0–20% | 586 | 13.6% | 12.5% |
| 20–40% | 504 | 28.6% | 20.4% |
| 40–60% | 80 | 46.4% | **76.3%** |
| 60–80% | 6 | 76.3% | 100.0% |
| 80–100% | 6 | 88.4% | 100.0% |

POD **10.4%** · FAR **3.7%** · CSI **10.4%** · bias **0.11**

The model is well calibrated at the bottom and badly **under-confident** above 40% — when it says 46% it rains 76% of the time. Bias 0.11 says it calls rain about a ninth as often as it rains. None of that is visible from the Brier row, which is exactly the argument in the issue.

## Design notes

- **5 bins, not 10.** At ~1,200 holdout rows a 10-bin table is mostly empty cells, and an "observed frequency" over 3 samples is noise presented as a measurement. `nBins` is a parameter if you'd rather have 10 once the diary is bigger.
- **Empty bins render `—`, not `0%`.** "Nothing landed in this band" and "it never rained in this band" are different claims and shouldn't look identical.
- **Zero denominators give `null`, never `NaN`.** "It never rained in the holdout" is not "we detected nothing".
- **Maths lives in `src/lib/` with its own `bun test` file**, matching `nowcast.js` / `log-csv.js`, so the numbers on the board are unit-tested instead of living only inside Astro frontmatter.

## Verification

Beyond the unit tests, I checked the rendered page against the confusion matrix it prints (TP=26, FP=1, FN=223, TN=932) by hand:

```
POD  = 26/249  = 10.4%   ✓ matches page
FAR  =  1/27   =  3.7%   ✓
CSI  = 26/250  = 10.4%   ✓
bias = 27/249  =  0.11   ✓
```

And the bins account for every holdout hour exactly once: 586+504+80+6+6 = **1,182** = `nTest`.

| gate | result |
| --- | --- |
| `bun test src/lib` | 31 pass, 0 fail (14 new) |
| `pytest` | 33 passed |
| `bun run build` | clean, page renders |

## Not done

The optional `public/metrics.json` dump. `metrics.json` is written by `pipeline/health.py`, so putting the bins there means a second implementation of this maths in Python and keeping the two in step. Happy to add it if you want it, but it seemed worse than leaving it out of a first pass — say the word.

`bun.lock` changed when I installed deps locally; deliberately not committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added holdout performance metrics for logistic models, including POD, FAR, CSI, and bias.
  - Added a five-bin reliability table showing forecast probabilities compared with observed outcomes.
  - Metrics now handle boundary values, incomplete data, empty bins, and unavailable calculations gracefully.
  - Scoreboard displays clearer headings, notes, and formatting for rates and ratios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->