### PR TITLE
ops: alert when collect goes stale >6h (closes #5)

### DIFF
--- a/.github/workflows/staleness-alert.yml
+++ b/.github/workflows/staleness-alert.yml
@@ -1,0 +1,125 @@
+name: staleness-alert
+
+# The push side of freshness. `collect` runs hourly and the scoreboard shows a
+# stale banner, but nobody is watching the scoreboard at 3am — and a cron can
+# "succeed" while quietly logging nothing, which is how the mid-monsoon diary gap
+# went unnoticed for weeks.
+#
+# This runs the same health gate the CLI exposes and, when the diary goes stale,
+# opens a GitHub issue (and optionally pings Discord). It closes the issue again
+# once collection recovers, so a green repo means a fresh diary.
+on:
+  schedule:
+    - cron: "40 */6 * * *"   # every 6h, offset off the :05 collector
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: staleness-alert
+  cancel-in-progress: false
+
+env:
+  STALE_HOURS: "6"
+  ISSUE_LABEL: stale-diary
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install deps
+        run: uv sync --frozen
+
+      # continue-on-error: a non-zero exit here is the SIGNAL, not a broken job.
+      - name: Check diary freshness
+        id: health
+        continue-on-error: true
+        run: |
+          set +e
+          uv run python -m pipeline.health --fail-stale "$STALE_HOURS" > health.txt 2>&1
+          code=$?
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          cat health.txt
+          {
+            echo 'report<<HEALTH_EOF'
+            tail -c 3000 health.txt
+            echo HEALTH_EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the staleness issue
+        if: steps.health.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT: ${{ steps.health.outputs.report }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --state open --label "$ISSUE_LABEL" \
+            --json number --jq '.[0].number // empty')
+
+          body=$(printf '%s\n' \
+            "\`pipeline.health --fail-stale $STALE_HOURS\` failed: the diary has no fresh row." \
+            "" \
+            "Most likely the hourly \`collect\` workflow is failing, or is succeeding while writing nothing." \
+            "" \
+            "**Health report**" \
+            '```' \
+            "$REPORT" \
+            '```' \
+            "" \
+            "Run: $RUN_URL" \
+            "" \
+            "_This issue is opened and closed automatically by \`staleness-alert\`._")
+
+          if [ -n "$existing" ]; then
+            # Already reported. Comment rather than opening a duplicate every 6h.
+            gh issue comment "$existing" --body "Still stale as of $(date -u +'%Y-%m-%dT%H:%MZ').
+
+          Run: $RUN_URL"
+          else
+            gh label create "$ISSUE_LABEL" --color B60205 \
+              --description "Diary collection has gone stale" 2>/dev/null || true
+            gh issue create \
+              --title "Diary is stale: no fresh row in ${STALE_HOURS}h" \
+              --label "$ISSUE_LABEL" \
+              --body "$body"
+          fi
+
+      - name: Notify Discord
+        # Optional: only fires when the webhook secret is configured.
+        if: steps.health.outputs.exit_code != '0' && env.DISCORD_WEBHOOK != ''
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n --arg content "🌧️ **mumbai-rain**: diary is stale (no fresh row in ${STALE_HOURS}h). $RUN_URL" \
+            '{content: $content}' \
+          | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+
+      - name: Close the staleness issue once collection recovers
+        if: steps.health.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list --state open --label "$ISSUE_LABEL" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Collection recovered: the diary is fresh within ${STALE_HOURS}h again."
+          fi
+
+      # Surface the failure on the workflow itself too, so a red run in the
+      # Actions tab means the same thing as an open issue.
+      - name: Fail the run when stale
+        if: steps.health.outputs.exit_code != '0'
+        run: |
+          echo "::error::Diary is stale — no fresh row in ${STALE_HOURS}h"
+          exit 1


### PR DESCRIPTION
Closes #5.

The scoreboard already shows a stale banner, but that's the *pull* side — nobody is watching it at 3am, and a cron can "succeed" while logging nothing, which is how the mid-monsoon gap went unnoticed. This is the push side.

`.github/workflows/staleness-alert.yml` runs every 6h (offset off the `:05` collector) and calls the gate that already exists: `uv run python -m pipeline.health --fail-stale 6`.

### Three design points

- **It does not open a fresh issue every 6 hours.** It looks for an open issue labelled `stale-diary` first and comments on that instead. A week-long outage is one issue with a comment trail, not 28 duplicates — which is the difference between an alert you keep and one you mute.
- **It closes the issue automatically once collection recovers.** So "no open `stale-diary` issue" is a signal you can trust, rather than something a human has to tidy up.
- **Discord is optional.** It only fires when `DISCORD_WEBHOOK` is set; the GitHub-issue path needs no setup at all. The issue offered either, so this does the zero-config one by default and the webhook as a bonus.

The health step uses `continue-on-error: true` because a non-zero exit there is the *signal*, not a broken job; a final step re-fails the run so a red Actions tab and an open issue mean the same thing.

Uses only `gh` (preinstalled on runners) and `github.token` — no third-party actions, matching the dependency-light style of `collect.yml`. Permissions are scoped to `contents: read` + `issues: write`.

### Verification

- Workflow YAML parses (`yaml.safe_load`) — 1 job, 8 steps, permissions as above.
- Confirmed the gate genuinely trips rather than trusting the issue's hint: with a deliberately tiny threshold, `pipeline.health --fail-stale 0.0001` exits **1** with `FAIL stale: hours_since_last_issue=0.2 > 0.0001`. At the real `6` threshold it exits 0 against current data, as expected.
- `public/metrics.json` is rewritten as a side effect of running health locally; deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated diary freshness monitoring that runs every six hours or on demand.
  * Creates or updates a clearly labeled alert when diary content becomes stale.
  * Optionally sends notifications to Discord for faster awareness.
  * Automatically closes the alert once diary freshness is restored.

* **Bug Fixes**
  * Monitoring now reports failures when stale content remains unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->